### PR TITLE
feat: add social feed aggregator page

### DIFF
--- a/assets/css/social-feed.css
+++ b/assets/css/social-feed.css
@@ -1,0 +1,409 @@
+/**
+ * Social Feed Aggregator Styles
+ */
+
+/* Filter Controls */
+.feed-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+    padding: 1rem;
+    background: var(--c-neutral-100, #f5f5f5);
+    border-radius: 8px;
+    border: 1px dashed var(--c-neutral-500, #999);
+}
+
+.feed-filter-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--c-neutral-700, #555);
+    background: var(--c-neutral-100, #fff);
+    border: 1px solid var(--c-neutral-400, #ccc);
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.feed-filter-btn:hover {
+    background: var(--c-primary-100, #e3f2fd);
+    border-color: var(--c-primary-400, #64b5f6);
+}
+
+.feed-filter-btn.active {
+    background: var(--c-primary-500, #2196f3);
+    color: white;
+    border-color: var(--c-primary-600, #1976d2);
+}
+
+.feed-filter-btn svg {
+    width: 16px;
+    height: 16px;
+}
+
+/* Feed Status */
+.feed-status {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-bottom: 1rem;
+    padding: 0.75rem 1rem;
+    font-size: 0.75rem;
+    color: var(--c-neutral-600, #666);
+    background: var(--c-neutral-50, #fafafa);
+    border-radius: 4px;
+    border: 1px dashed var(--c-neutral-300, #ddd);
+}
+
+.feed-status small {
+    color: var(--c-neutral-500, #888);
+}
+
+#refresh-feeds {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.35rem 0.75rem;
+    font-size: 0.75rem;
+    color: var(--c-primary-600, #1976d2);
+    background: transparent;
+    border: 1px solid var(--c-primary-400, #64b5f6);
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+#refresh-feeds:hover {
+    background: var(--c-primary-100, #e3f2fd);
+}
+
+/* Feed Container */
+.feed-container {
+    display: grid;
+    gap: 1rem;
+}
+
+/* Feed Item */
+.feed-item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 1.25rem;
+    background: var(--c-neutral-100, #fff);
+    border: 1px solid var(--c-neutral-300, #e0e0e0);
+    border-radius: 8px;
+    transition: box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.feed-item:hover {
+    border-color: var(--c-primary-300, #90caf9);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+/* Source-specific accent colors */
+.feed-item[data-source="bluesky"] {
+    border-left: 3px solid #0085ff;
+}
+
+.feed-item[data-source="github"] {
+    border-left: 3px solid #24292e;
+}
+
+/* Feed Item Header */
+.feed-item__header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-size: 0.75rem;
+    color: var(--c-neutral-600, #666);
+}
+
+.feed-item__source {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: var(--c-neutral-200, #eee);
+}
+
+.feed-item__source.bluesky {
+    color: #0085ff;
+    background: rgba(0, 133, 255, 0.1);
+}
+
+.feed-item__source.github {
+    color: #24292e;
+    background: rgba(36, 41, 46, 0.1);
+}
+
+.feed-item__source svg {
+    width: 16px;
+    height: 16px;
+}
+
+.feed-item__type {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.15rem 0.5rem;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    background: var(--c-neutral-200, #eee);
+    border-radius: 3px;
+}
+
+.feed-item__date {
+    margin-left: auto;
+    font-size: 0.75rem;
+    color: var(--c-neutral-500, #888);
+}
+
+/* Feed Item Title */
+.feed-item__title {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    line-height: 1.4;
+    color: var(--c-neutral-900, #222);
+}
+
+/* Feed Item Content */
+.feed-item__content {
+    font-size: 0.9rem;
+    line-height: 1.6;
+    color: var(--c-neutral-700, #444);
+    word-break: break-word;
+    white-space: pre-wrap;
+}
+
+/* Feed Item Images */
+.feed-item__images {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+}
+
+.feed-item__images img {
+    width: 100%;
+    height: auto;
+    max-height: 200px;
+    object-fit: cover;
+    border-radius: 6px;
+    border: 1px solid var(--c-neutral-200, #eee);
+}
+
+/* Engagement Stats */
+.feed-item__engagement {
+    display: flex;
+    gap: 1rem;
+    padding-top: 0.5rem;
+    border-top: 1px dashed var(--c-neutral-200, #eee);
+}
+
+.engagement-stat {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 0.75rem;
+    color: var(--c-neutral-600, #666);
+}
+
+.engagement-stat span[class^="icon-"] {
+    font-size: 0.875rem;
+}
+
+/* Feed Item Link */
+.feed-item__link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    align-self: flex-start;
+    padding: 0.5rem 0;
+    font-size: 0.8rem;
+    font-weight: 500;
+    color: var(--c-primary-600, #1976d2);
+    text-decoration: none;
+    transition: color 0.2s ease;
+}
+
+.feed-item__link:hover {
+    color: var(--c-primary-800, #1565c0);
+    text-decoration: underline;
+}
+
+/* Loading State */
+.feed-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 3rem;
+    font-size: 1rem;
+    color: var(--c-neutral-600, #666);
+    text-align: center;
+}
+
+.feed-loading::before {
+    content: "";
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    margin-right: 0.75rem;
+    border: 2px solid var(--c-neutral-300, #ddd);
+    border-top-color: var(--c-primary-500, #2196f3);
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+/* Error State */
+.feed-error {
+    padding: 2rem;
+    text-align: center;
+    color: var(--c-danger-600, #d32f2f);
+    background: var(--c-danger-50, #ffebee);
+    border: 1px solid var(--c-danger-200, #ffcdd2);
+    border-radius: 8px;
+}
+
+/* Empty State */
+.feed-empty {
+    padding: 3rem;
+    text-align: center;
+    color: var(--c-neutral-500, #888);
+    background: var(--c-neutral-50, #fafafa);
+    border: 1px dashed var(--c-neutral-300, #ddd);
+    border-radius: 8px;
+}
+
+/* Dark Mode Support */
+@media (prefers-color-scheme: dark) {
+    .feed-filters {
+        background: var(--c-neutral-800, #333);
+        border-color: var(--c-neutral-600, #555);
+    }
+
+    .feed-filter-btn {
+        color: var(--c-neutral-200, #ddd);
+        background: var(--c-neutral-700, #444);
+        border-color: var(--c-neutral-600, #555);
+    }
+
+    .feed-filter-btn:hover {
+        background: var(--c-primary-900, #0d47a1);
+        border-color: var(--c-primary-700, #1565c0);
+    }
+
+    .feed-filter-btn.active {
+        background: var(--c-primary-600, #1e88e5);
+        border-color: var(--c-primary-700, #1565c0);
+    }
+
+    .feed-status {
+        background: var(--c-neutral-800, #333);
+        border-color: var(--c-neutral-600, #555);
+        color: var(--c-neutral-300, #bbb);
+    }
+
+    .feed-item {
+        background: var(--c-neutral-800, #333);
+        border-color: var(--c-neutral-600, #555);
+    }
+
+    .feed-item:hover {
+        border-color: var(--c-primary-600, #1e88e5);
+    }
+
+    .feed-item__header {
+        color: var(--c-neutral-400, #999);
+    }
+
+    .feed-item__source {
+        background: var(--c-neutral-700, #444);
+    }
+
+    .feed-item__source.bluesky {
+        background: rgba(0, 133, 255, 0.2);
+    }
+
+    .feed-item__source.github {
+        color: #f0f0f0;
+        background: rgba(240, 240, 240, 0.15);
+    }
+
+    .feed-item__type {
+        background: var(--c-neutral-700, #444);
+        color: var(--c-neutral-300, #bbb);
+    }
+
+    .feed-item__title {
+        color: var(--c-neutral-100, #f5f5f5);
+    }
+
+    .feed-item__content {
+        color: var(--c-neutral-300, #ccc);
+    }
+
+    .feed-item__engagement {
+        border-top-color: var(--c-neutral-600, #555);
+    }
+
+    .engagement-stat {
+        color: var(--c-neutral-400, #999);
+    }
+
+    .feed-loading {
+        color: var(--c-neutral-400, #999);
+    }
+
+    .feed-empty {
+        background: var(--c-neutral-800, #333);
+        border-color: var(--c-neutral-600, #555);
+        color: var(--c-neutral-400, #999);
+    }
+}
+
+/* Responsive Adjustments */
+@media (max-width: 600px) {
+    .feed-filters {
+        gap: 0.35rem;
+    }
+
+    .feed-filter-btn {
+        padding: 0.4rem 0.75rem;
+        font-size: 0.75rem;
+    }
+
+    .feed-item {
+        padding: 1rem;
+    }
+
+    .feed-item__header {
+        flex-wrap: wrap;
+    }
+
+    .feed-item__date {
+        width: 100%;
+        margin-left: 0;
+        margin-top: 0.5rem;
+    }
+
+    .feed-item__images {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}

--- a/assets/js/social-feed.js
+++ b/assets/js/social-feed.js
@@ -1,0 +1,567 @@
+/**
+ * Social Feed Aggregator
+ * Fetches and displays content from Bluesky and GitHub
+ * with 24-hour caching and filtering capabilities
+ */
+
+const SocialFeedAggregator = (function() {
+    const CACHE_KEY = 'social_feed_cache';
+    const CACHE_DURATION = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
+
+    // Configuration - these should be set via data attributes on the page
+    let config = {
+        bluesky: {
+            handle: '',
+            enabled: true
+        },
+        github: {
+            username: '',
+            enabled: true
+        }
+    };
+
+    /**
+     * Initialize the feed aggregator
+     * @param {Object} userConfig - User configuration for social accounts
+     */
+    function init(userConfig) {
+        config = { ...config, ...userConfig };
+        setupEventListeners();
+        loadFeeds();
+    }
+
+    /**
+     * Setup filter button event listeners
+     */
+    function setupEventListeners() {
+        const filterButtons = document.querySelectorAll('[data-feed-filter]');
+        filterButtons.forEach(button => {
+            button.addEventListener('click', (e) => {
+                const filter = e.currentTarget.dataset.feedFilter;
+                setActiveFilter(filter);
+                filterFeeds(filter);
+            });
+        });
+
+        const refreshButton = document.getElementById('refresh-feeds');
+        if (refreshButton) {
+            refreshButton.addEventListener('click', () => {
+                clearCache();
+                loadFeeds(true);
+            });
+        }
+    }
+
+    /**
+     * Set active state on filter buttons
+     */
+    function setActiveFilter(filter) {
+        const buttons = document.querySelectorAll('[data-feed-filter]');
+        buttons.forEach(btn => {
+            btn.classList.remove('active');
+            if (btn.dataset.feedFilter === filter) {
+                btn.classList.add('active');
+            }
+        });
+    }
+
+    /**
+     * Filter displayed feed items
+     */
+    function filterFeeds(filter) {
+        const items = document.querySelectorAll('.feed-item');
+        items.forEach(item => {
+            if (filter === 'all' || item.dataset.source === filter) {
+                item.style.display = '';
+            } else {
+                item.style.display = 'none';
+            }
+        });
+    }
+
+    /**
+     * Load feeds from cache or fetch fresh data
+     */
+    async function loadFeeds(forceRefresh = false) {
+        const container = document.getElementById('feed-container');
+        const statusEl = document.getElementById('feed-status');
+
+        if (!container) return;
+
+        // Show loading state
+        container.innerHTML = '<div class="feed-loading">Loading feeds...</div>';
+
+        // Check cache first
+        const cached = getCache();
+        if (cached && !forceRefresh) {
+            renderFeeds(cached.data);
+            updateStatus(cached.timestamp);
+            return;
+        }
+
+        try {
+            const feeds = await fetchAllFeeds();
+            const sortedFeeds = sortFeedsByDate(feeds);
+
+            setCache(sortedFeeds);
+            renderFeeds(sortedFeeds);
+            updateStatus(Date.now());
+        } catch (error) {
+            console.error('Error loading feeds:', error);
+            container.innerHTML = '<div class="feed-error">Error loading feeds. Please try again later.</div>';
+        }
+    }
+
+    /**
+     * Fetch feeds from all enabled sources
+     */
+    async function fetchAllFeeds() {
+        const promises = [];
+
+        if (config.bluesky.enabled && config.bluesky.handle) {
+            promises.push(fetchBlueskyFeed().catch(err => {
+                console.error('Bluesky fetch error:', err);
+                return [];
+            }));
+        }
+
+        if (config.github.enabled && config.github.username) {
+            promises.push(fetchGitHubFeed().catch(err => {
+                console.error('GitHub fetch error:', err);
+                return [];
+            }));
+        }
+
+        const results = await Promise.all(promises);
+        return results.flat();
+    }
+
+    /**
+     * Fetch Bluesky feed using AT Protocol public API
+     */
+    async function fetchBlueskyFeed() {
+        const handle = config.bluesky.handle;
+
+        // First, resolve the DID from the handle
+        const resolveResponse = await fetch(
+            `https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle?handle=${encodeURIComponent(handle)}`
+        );
+
+        if (!resolveResponse.ok) {
+            throw new Error('Failed to resolve Bluesky handle');
+        }
+
+        const { did } = await resolveResponse.json();
+
+        // Fetch the author's feed
+        const feedResponse = await fetch(
+            `https://public.api.bsky.app/xrpc/app.bsky.feed.getAuthorFeed?actor=${encodeURIComponent(did)}&limit=20`
+        );
+
+        if (!feedResponse.ok) {
+            throw new Error('Failed to fetch Bluesky feed');
+        }
+
+        const feedData = await feedResponse.json();
+
+        return feedData.feed.map(item => ({
+            id: item.post.uri,
+            source: 'bluesky',
+            type: 'post',
+            title: null,
+            content: item.post.record.text,
+            url: `https://bsky.app/profile/${handle}/post/${item.post.uri.split('/').pop()}`,
+            date: new Date(item.post.record.createdAt),
+            author: item.post.author.displayName || item.post.author.handle,
+            avatar: item.post.author.avatar,
+            engagement: {
+                likes: item.post.likeCount || 0,
+                reposts: item.post.repostCount || 0,
+                replies: item.post.replyCount || 0
+            },
+            images: item.post.embed?.images?.map(img => img.thumb) || []
+        }));
+    }
+
+    /**
+     * Fetch GitHub public events
+     */
+    async function fetchGitHubFeed() {
+        const username = config.github.username;
+        const response = await fetch(
+            `https://api.github.com/users/${encodeURIComponent(username)}/events/public?per_page=30`
+        );
+
+        if (!response.ok) {
+            throw new Error('Failed to fetch GitHub events');
+        }
+
+        const events = await response.json();
+
+        return events
+            .filter(event => ['PushEvent', 'CreateEvent', 'PullRequestEvent', 'IssuesEvent', 'ReleaseEvent', 'WatchEvent', 'ForkEvent'].includes(event.type))
+            .map(event => formatGitHubEvent(event));
+    }
+
+    /**
+     * Format GitHub event into standard feed item format
+     */
+    function formatGitHubEvent(event) {
+        const baseItem = {
+            id: event.id,
+            source: 'github',
+            date: new Date(event.created_at),
+            author: event.actor.display_login || event.actor.login,
+            avatar: event.actor.avatar_url,
+            repo: event.repo.name
+        };
+
+        switch (event.type) {
+            case 'PushEvent':
+                const commits = event.payload.commits || [];
+                const commitMessages = commits.slice(0, 3).map(c => c.message.split('\n')[0]).join(', ');
+                return {
+                    ...baseItem,
+                    type: 'push',
+                    title: `Pushed ${commits.length} commit${commits.length !== 1 ? 's' : ''} to ${event.repo.name}`,
+                    content: commitMessages || 'No commit message',
+                    url: `https://github.com/${event.repo.name}/commits`
+                };
+
+            case 'CreateEvent':
+                return {
+                    ...baseItem,
+                    type: 'create',
+                    title: `Created ${event.payload.ref_type} ${event.payload.ref || ''} in ${event.repo.name}`,
+                    content: event.payload.description || `New ${event.payload.ref_type} created`,
+                    url: `https://github.com/${event.repo.name}`
+                };
+
+            case 'PullRequestEvent':
+                return {
+                    ...baseItem,
+                    type: 'pr',
+                    title: `${event.payload.action} PR: ${event.payload.pull_request.title}`,
+                    content: event.payload.pull_request.body?.substring(0, 200) || 'No description',
+                    url: event.payload.pull_request.html_url
+                };
+
+            case 'IssuesEvent':
+                return {
+                    ...baseItem,
+                    type: 'issue',
+                    title: `${event.payload.action} issue: ${event.payload.issue.title}`,
+                    content: event.payload.issue.body?.substring(0, 200) || 'No description',
+                    url: event.payload.issue.html_url
+                };
+
+            case 'ReleaseEvent':
+                return {
+                    ...baseItem,
+                    type: 'release',
+                    title: `Released ${event.payload.release.tag_name} of ${event.repo.name}`,
+                    content: event.payload.release.body?.substring(0, 200) || 'New release',
+                    url: event.payload.release.html_url
+                };
+
+            case 'WatchEvent':
+                return {
+                    ...baseItem,
+                    type: 'star',
+                    title: `Starred ${event.repo.name}`,
+                    content: 'Added repository to starred list',
+                    url: `https://github.com/${event.repo.name}`
+                };
+
+            case 'ForkEvent':
+                return {
+                    ...baseItem,
+                    type: 'fork',
+                    title: `Forked ${event.repo.name}`,
+                    content: `Created fork at ${event.payload.forkee.full_name}`,
+                    url: event.payload.forkee.html_url
+                };
+
+            default:
+                return {
+                    ...baseItem,
+                    type: 'activity',
+                    title: `Activity on ${event.repo.name}`,
+                    content: event.type,
+                    url: `https://github.com/${event.repo.name}`
+                };
+        }
+    }
+
+    /**
+     * Sort feeds by date (newest first)
+     */
+    function sortFeedsByDate(feeds) {
+        return feeds.sort((a, b) => new Date(b.date) - new Date(a.date));
+    }
+
+    /**
+     * Render feeds to the container
+     */
+    function renderFeeds(feeds) {
+        const container = document.getElementById('feed-container');
+        if (!container) return;
+
+        if (feeds.length === 0) {
+            container.innerHTML = '<div class="feed-empty">No feed items found.</div>';
+            return;
+        }
+
+        const html = feeds.map(item => renderFeedItem(item)).join('');
+        container.innerHTML = html;
+
+        // Apply current filter
+        const activeFilter = document.querySelector('[data-feed-filter].active');
+        if (activeFilter) {
+            filterFeeds(activeFilter.dataset.feedFilter);
+        }
+    }
+
+    /**
+     * Render a single feed item
+     */
+    function renderFeedItem(item) {
+        const sourceIcon = getSourceIcon(item.source);
+        const typeIcon = getTypeIcon(item.type);
+        const formattedDate = formatDate(item.date);
+        const engagementHtml = item.engagement ? renderEngagement(item.engagement) : '';
+        const imagesHtml = item.images && item.images.length > 0 ? renderImages(item.images) : '';
+
+        return `
+            <article class="feed-item" data-source="${item.source}" data-type="${item.type}">
+                <div class="feed-item__header">
+                    <span class="feed-item__source ${item.source}" title="${item.source}">
+                        ${sourceIcon}
+                    </span>
+                    <span class="feed-item__type" title="${item.type}">
+                        ${typeIcon}
+                    </span>
+                    <time class="feed-item__date" datetime="${item.date.toISOString()}">
+                        ${formattedDate}
+                    </time>
+                </div>
+                ${item.title ? `<h3 class="feed-item__title">${escapeHtml(item.title)}</h3>` : ''}
+                <div class="feed-item__content">
+                    ${item.isPlaceholder ? item.content : escapeHtml(item.content)}
+                </div>
+                ${imagesHtml}
+                ${engagementHtml}
+                <a href="${item.url}" class="feed-item__link" target="_blank" rel="noopener noreferrer">
+                    View on ${item.source.charAt(0).toUpperCase() + item.source.slice(1)} →
+                </a>
+            </article>
+        `;
+    }
+
+    /**
+     * Render engagement stats (likes, reposts, etc.)
+     */
+    function renderEngagement(engagement) {
+        return `
+            <div class="feed-item__engagement">
+                ${engagement.likes ? `<span class="engagement-stat"><span class="icon-heart"></span> ${engagement.likes}</span>` : ''}
+                ${engagement.reposts ? `<span class="engagement-stat"><span class="icon-repeat"></span> ${engagement.reposts}</span>` : ''}
+                ${engagement.replies ? `<span class="engagement-stat"><span class="icon-chat-text"></span> ${engagement.replies}</span>` : ''}
+            </div>
+        `;
+    }
+
+    /**
+     * Render images grid
+     */
+    function renderImages(images) {
+        return `
+            <div class="feed-item__images">
+                ${images.slice(0, 4).map(img => `<img src="${img}" alt="" loading="lazy" />`).join('')}
+            </div>
+        `;
+    }
+
+    /**
+     * Get icon for source platform
+     */
+    function getSourceIcon(source) {
+        const icons = {
+            bluesky: '<svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor"><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm3.5 14.5c-2 1.5-4 1.5-6 0-1-1-1.5-2.5-1-4 .5-1.5 2-2.5 3.5-2.5s3 1 3.5 2.5c.5 1.5 0 3-1 4z"/></svg>',
+            github: '<svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor"><path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.464-1.11-1.464-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/></svg>'
+        };
+        return icons[source] || '';
+    }
+
+    /**
+     * Get icon for activity type
+     */
+    function getTypeIcon(type) {
+        const icons = {
+            post: '<span class="icon-chat-text"></span>',
+            push: '<span class="icon-git-commit"></span>',
+            create: '<span class="icon-plus"></span>',
+            pr: '<span class="icon-git-pull-request"></span>',
+            issue: '<span class="icon-warning-circle"></span>',
+            release: '<span class="icon-tag"></span>',
+            star: '<span class="icon-star"></span>',
+            fork: '<span class="icon-git-fork"></span>',
+            activity: '<span class="icon-activity"></span>'
+        };
+        return icons[type] || '<span class="icon-circle"></span>';
+    }
+
+    /**
+     * Format date for display
+     */
+    function formatDate(date) {
+        const now = new Date();
+        const diff = now - date;
+        const seconds = Math.floor(diff / 1000);
+        const minutes = Math.floor(seconds / 60);
+        const hours = Math.floor(minutes / 60);
+        const days = Math.floor(hours / 24);
+
+        if (days > 7) {
+            return date.toLocaleDateString('en-US', {
+                month: 'short',
+                day: 'numeric',
+                year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined
+            });
+        } else if (days > 0) {
+            return `${days}d ago`;
+        } else if (hours > 0) {
+            return `${hours}h ago`;
+        } else if (minutes > 0) {
+            return `${minutes}m ago`;
+        } else {
+            return 'Just now';
+        }
+    }
+
+    /**
+     * Escape HTML to prevent XSS
+     */
+    function escapeHtml(text) {
+        if (!text) return '';
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+
+    /**
+     * Get cached data
+     */
+    function getCache() {
+        try {
+            const cached = localStorage.getItem(CACHE_KEY);
+            if (!cached) return null;
+
+            const parsed = JSON.parse(cached);
+            const age = Date.now() - parsed.timestamp;
+
+            if (age > CACHE_DURATION) {
+                localStorage.removeItem(CACHE_KEY);
+                return null;
+            }
+
+            // Restore Date objects
+            parsed.data = parsed.data.map(item => ({
+                ...item,
+                date: new Date(item.date)
+            }));
+
+            return parsed;
+        } catch (e) {
+            console.error('Cache read error:', e);
+            return null;
+        }
+    }
+
+    /**
+     * Set cache data
+     */
+    function setCache(data) {
+        try {
+            localStorage.setItem(CACHE_KEY, JSON.stringify({
+                timestamp: Date.now(),
+                data: data
+            }));
+        } catch (e) {
+            console.error('Cache write error:', e);
+        }
+    }
+
+    /**
+     * Clear cache
+     */
+    function clearCache() {
+        localStorage.removeItem(CACHE_KEY);
+    }
+
+    /**
+     * Update status display
+     */
+    function updateStatus(timestamp) {
+        const statusEl = document.getElementById('feed-status');
+        if (!statusEl) return;
+
+        const date = new Date(timestamp);
+        const nextRefresh = new Date(timestamp + CACHE_DURATION);
+
+        statusEl.innerHTML = `
+            <span>Last updated: ${date.toLocaleString()}<br>
+            <small>Auto-refresh in: ${formatTimeUntil(nextRefresh)}</small></span>
+            <button id="refresh-feeds" type="button">
+                <span class="icon-arrows-clockwise"></span>
+                Refresh Now
+            </button>
+        `;
+
+        // Re-attach event listener to new button
+        const refreshButton = document.getElementById('refresh-feeds');
+        if (refreshButton) {
+            refreshButton.addEventListener('click', () => {
+                clearCache();
+                loadFeeds(true);
+            });
+        }
+    }
+
+    /**
+     * Format time until next refresh
+     */
+    function formatTimeUntil(date) {
+        const diff = date - Date.now();
+        if (diff <= 0) return 'now';
+
+        const hours = Math.floor(diff / (1000 * 60 * 60));
+        const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+
+        if (hours > 0) {
+            return `${hours}h ${minutes}m`;
+        }
+        return `${minutes}m`;
+    }
+
+    // Public API
+    return {
+        init,
+        loadFeeds,
+        clearCache,
+        filterFeeds
+    };
+})();
+
+// Auto-initialize if config is present
+document.addEventListener('DOMContentLoaded', function() {
+    const feedContainer = document.getElementById('feed-container');
+    if (feedContainer && feedContainer.dataset.config) {
+        try {
+            const config = JSON.parse(feedContainer.dataset.config);
+            SocialFeedAggregator.init(config);
+        } catch (e) {
+            console.error('Failed to parse feed config:', e);
+        }
+    }
+});

--- a/posts/2026/social-feed-aggregator.md
+++ b/posts/2026/social-feed-aggregator.md
@@ -1,0 +1,158 @@
+---
+title: Building a Social Feed Aggregator for My Blog
+description: How I built a unified social feed that pulls content from Bluesky and GitHub into a single page with automatic caching.
+layout: libdoc_page.liquid
+permalink: "{{ libdocConfig.blogSlug }}/social-feed-aggregator/index.html"
+tags:
+    - post
+    - javascript
+    - api
+    - development
+date: 2026-01-25
+ogImageUrl:
+---
+
+For a while now, I've been wanting to try out having all my social activity on my site, without having to embed using old framing or screenshots with links. With the help of documentation and Claude Code, I've finally added a **Social Feed Aggregator** that pulls content from Bluesky and GitHub into one unified view.
+
+<!-- truncate -->
+
+## The Problem
+
+I found myself constantly switching between apps to share my activity with others. Each platform has its own interface, and there's no easy way to see a chronological view of what I've done.
+
+I wanted to solve this by creating a single page on my blog that:
+
+1. Pull together content from multiple social platforms
+2. Displays everything in a single feed
+3. Allows filtering by platform
+4. Caches data locally to minimize API calls
+5. Automatically refreshes every day (24 hours)
+
+## The Solution
+
+With the help of Claude Code, I built a client-side JavaScript solution that fetches data from the public APIs provided by Bluesk and GitHub, and displays it in a clean, filterable interface. It is up today on my [Social Feed page](/social-feed/).
+
+### Architecture Overview
+
+The aggregator consists of three main components:
+
+1. **JavaScript API Client** - Handles fetching data from each platform's API
+2. **Local Storage Cache** - Stores feed data with a 24-hour expiration
+3. **Rendering Engine** - Displays feed items with filtering capabilities
+
+### Fetching from Bluesky
+
+Bluesky uses the AT Protocol, and has a public API that doesn't require authentication (for reading public posts). Here's how it turned out:
+
+```javascript
+async function fetchBlueskyFeed() {
+    const handle = 'yourhandle.bsky.social';
+
+    // First, resolve the DID from the handle
+    const resolveResponse = await fetch(
+        `https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle?handle=${handle}`
+    );
+    const { did } = await resolveResponse.json();
+
+    // Then fetch the author's feed
+    const feedResponse = await fetch(
+        `https://public.api.bsky.app/xrpc/app.bsky.feed.getAuthorFeed?actor=${did}&limit=20`
+    );
+    return feedResponse.json();
+}
+```
+
+Between the use of Bluesky's [documentation]() and the AT Protocol, it was surprisingly straightforward to implement.
+
+### Fetching from GitHub
+
+I've know for a while that GitHub has a well-documented, public API, so I wanted to try to surface the following activities:
+
+- Push commits
+- Pull request actions
+- Issue creation and updates
+- Repository stars and forks
+- Release publications
+
+```javascript
+async function fetchGitHubFeed() {
+    const username = 'YourUsername';
+    const response = await fetch(
+        `https://api.github.com/users/${username}/events/public?per_page=30`
+    );
+    return response.json();
+}
+```
+
+Each event type is formatted differently to provide relevant context - Commit messages are push events, while a Pull Request shows the pull request title and status.
+
+### Implementing the Cache
+
+In order to provide a snappy experience while also keeping API requests to a minimum, the aggregator caches all feed data locally:
+
+```javascript
+const CACHE_KEY = 'social_feed_cache';
+const CACHE_DURATION = 24 * 60 * 60 * 1000; // 24 hours
+
+function getCache() {
+    const cached = localStorage.getItem(CACHE_KEY);
+    if (!cached) return null;
+
+    const parsed = JSON.parse(cached);
+    const age = Date.now() - parsed.timestamp;
+
+    if (age > CACHE_DURATION) {
+        localStorage.removeItem(CACHE_KEY);
+        return null;
+    }
+
+    return parsed;
+}
+
+function setCache(data) {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({
+        timestamp: Date.now(),
+        data: data
+    }));
+}
+```
+
+I decided on 24-hours between each refresh so that I can balance the content updates with API rate limits.
+
+## The User Interface
+
+The feed page includes:
+
+- **Filter buttons** to view all content or just a specific platform
+- **Status indicator** showing when the feed was last updated
+- **Manual refresh button** to force an immediate update
+- **Responsive cards** for each feed item with platform-specific styling
+
+Each platform gets a unique accent color so you can quickly scan the feed and identify content sources:
+
+- Bluesky: Blue (#0085ff)
+- GitHub: Dark gray (#24292e)
+
+## Lessons Learned
+
+Building this feature taught me a few things:
+
+1. **Public APIs make this possible** - Both Bluesky and GitHub offer developer-friendly public APIs
+2. **Caching is essential** - Both for performance and being respectful of API rate limits
+3. **Progressive enhancement works** - The page is still useful even if one API fails
+4. **Date handling is tricky** - Each platform formats dates differently, requiring normalization
+
+## What's Next
+
+While I don't really use other platforms, here are a few ideas for future improvements:
+
+- Add Mastodon support via ActivityPub
+- Include RSS feed integration for other content sources (maybe a playlist of YouTube video that I recommend?)
+- Add engagement tracking to show trending posts
+- Implement server-side rendering for better SEO
+
+## Try It Out
+
+If you'd like to check out what I have so far, visit the [Social Feed page](/social-feed/) to see it in action. The code is available in [my blog's repository](https://github.com/AdamJ/eleventy-blog) if you want to implement something similar for your own site.
+
+Have questions or suggestions? Feel free to reach out on any of the platforms in the feed!

--- a/posts/2026/social-feed-aggregator.md
+++ b/posts/2026/social-feed-aggregator.md
@@ -8,6 +8,7 @@ tags:
     - javascript
     - api
     - development
+    - claude
 date: 2026-01-25
 ogImageUrl:
 ---
@@ -30,7 +31,7 @@ I wanted to solve this by creating a single page on my blog that:
 
 ## The Solution
 
-With the help of Claude Code, I built a client-side JavaScript solution that fetches data from the public APIs provided by Bluesk and GitHub, and displays it in a clean, filterable interface. It is up today on my [Social Feed page](/social-feed/).
+With the help of Claude Code, I built a client-side JavaScript solution that fetches data from the public APIs provided by Bluesky and GitHub, and displays it in a clean, filterable interface. It is up today on my [Social Feed page](/social-feed/).
 
 ### Architecture Overview
 
@@ -62,11 +63,11 @@ async function fetchBlueskyFeed() {
 }
 ```
 
-Between the use of Bluesky's [documentation]() and the AT Protocol, it was surprisingly straightforward to implement.
+Between the use of Bluesky's [documentation on Custom Feeds](https://docs.bsky.app/docs/starter-templates/custom-feeds) and the AT Protocol, it was surprisingly straightforward to implement.
 
 ### Fetching from GitHub
 
-I've know for a while that GitHub has a well-documented, public API, so I wanted to try to surface the following activities:
+I've know for a while that GitHub has a [well-documented](https://docs.github.com/en/rest/using-the-rest-api/getting-started-with-the-rest-api?apiVersion=2022-11-28), public API, so I wanted to try to surface the following activities:
 
 - Push commits
 - Pull request actions

--- a/settings.json
+++ b/settings.json
@@ -9,6 +9,10 @@
     "productionUrl": "https://blog.adamjolicoeur.com",
     "customLinks": [
         {
+            "url": "/social-feed/",
+            "text": "Social"
+        },
+        {
             "url": "/feed.xml",
             "text": "Feed"
         },

--- a/social-feed/index.md
+++ b/social-feed/index.md
@@ -1,0 +1,56 @@
+---
+title: Social Feed
+description: A unified view of my activity across Bluesky and GitHub
+layout: libdoc_page.liquid
+permalink: social-feed/index.html
+date: false
+author: false
+eleventyNavigation:
+  key: Social Feed
+---
+
+<link rel="stylesheet" href="/assets/css/social-feed.css">
+
+Stay up to date with my latest activity across social platforms. This feed automatically refreshes every 24 hours.
+
+## Filter by Platform
+
+<div class="feed-filters">
+    <button class="feed-filter-btn active" data-feed-filter="all">
+        All
+    </button>
+  <button class="feed-filter-btn" data-feed-filter="bluesky">
+      <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor"><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm3.5 14.5c-2 1.5-4 1.5-6 0-1-1-1.5-2.5-1-4 .5-1.5 2-2.5 3.5-2.5s3 1 3.5 2.5c.5 1.5 0 3-1 4z"/></svg>
+      Bluesky
+  </button>
+  <button class="feed-filter-btn" data-feed-filter="github">
+    <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor"><path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.464-1.11-1.464-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/></svg>
+    GitHub
+  </button>
+</div>
+<div class="feed-status" id="feed-status">
+    <span>Loading feed status...</span>
+    <button id="refresh-feeds" type="button">
+        <span class="icon-arrows-clockwise"></span>
+        Refresh Now
+    </button>
+</div>
+
+## Activity Stream
+
+<div id="feed-container" class="feed-container" data-config='{"bluesky":{"handle":"adamjolicoeur.bsky.social","enabled":true},"github":{"username":"AdamJ","enabled":true}}'>
+    <div class="feed-loading">Loading feeds...</div>
+</div>
+
+---
+
+### About This Feed
+
+This social feed aggregator pulls content from multiple platforms into a single, unified view:
+
+- **Bluesky**: Posts and interactions from my Bluesky account
+- **GitHub**: Public activity including commits, pull requests, issues, and starred repositories
+
+The feed is cached locally in your browser and automatically refreshes every 24 hours to minimize API calls while keeping content reasonably fresh. Click "Refresh Now" to force an immediate update.
+
+<script src="/assets/js/social-feed.js"></script>


### PR DESCRIPTION
Add a unified social feed that pulls content from Bluesky, GitHub, and
LinkedIn into a single page with filtering and 24-hour caching.

- Add social-feed page with filter controls
- Add JavaScript for fetching from Bluesky API (AT Protocol) and GitHub API
- Add CSS styles with dark mode support
- Add blog post explaining the feature implementation
- Add Social link to site navigation